### PR TITLE
Add LoadFrom assembly resolution emulation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="IsExternalInit" Version="1.0.3" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/src/Nerdbank.NetStandardBridge/Nerdbank.NetStandardBridge.csproj
+++ b/src/Nerdbank.NetStandardBridge/Nerdbank.NetStandardBridge.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs
+++ b/src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Copyright (c) Microsoft Corporation. All rights reserved.
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;

--- a/src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs
+++ b/src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs
@@ -378,7 +378,7 @@ public class NetFrameworkAssemblyResolver
         AppDomain.CurrentDomain.AssemblyResolve += (s, e) =>
         {
             AssemblyName? redirectedAssemblyName = this.GetAssemblyNameByPolicy(new AssemblyName(e.Name));
-            if (redirectedAssemblyName is { CodeBase: not null } && File.Exists(redirectedAssemblyName.CodeBase))
+            if (redirectedAssemblyName is { CodeBase: not null } && this.FileExists(redirectedAssemblyName.CodeBase))
             {
                 return Assembly.LoadFile(redirectedAssemblyName.CodeBase);
             }

--- a/src/Nerdbank.NetStandardBridge/net462/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/net462/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.HookupResolver() -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(string! assemblyPath) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?

--- a/src/Nerdbank.NetStandardBridge/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/net6.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.A
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(string! assemblyPath) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.SearchForNearbyAssemblies.get -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.SearchForNearbyAssemblies.init -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?

--- a/src/Nerdbank.NetStandardBridge/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/net6.0/PublicAPI.Unshipped.txt
@@ -4,11 +4,10 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.HookupResolver(System.Runtime.Loader.AssemblyLoadContext! loadContext) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.HookupResolver(System.Runtime.Loader.AssemblyLoadContext! loadContext, bool blockMoreResolvers) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.LoadFrom(string! assemblyPath) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(string! assemblyPath) -> void
-Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.SearchForNearbyAssemblies.get -> bool
-Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.SearchForNearbyAssemblies.init -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?

--- a/src/Nerdbank.NetStandardBridge/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/net6.0/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.HookupResolver(System.Ru
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(string! assemblyPath) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?

--- a/src/Nerdbank.NetStandardBridge/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(string! assemblyPath) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?

--- a/src/Nerdbank.NetStandardBridge/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/netstandard2.1/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(string! assemblyPath) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?

--- a/test/Nerdbank.NetStandardBridge.Tests/NetFrameworkAssemblyResolverTests.cs
+++ b/test/Nerdbank.NetStandardBridge.Tests/NetFrameworkAssemblyResolverTests.cs
@@ -250,6 +250,22 @@ public class NetFrameworkAssemblyResolverTests
 #endif
     }
 
+    [Fact]
+    public void ProvideAssemblyPath_NoThrowOnNonExistentPath()
+    {
+        this.loader.ProvideAssemblyPath("no good path");
+        this.loader.ProvideAssemblyPath(Path.Combine(Environment.CurrentDirectory, "nonexistent.dll"));
+        Assert.Null(this.loader.Load(new AssemblyName("nonexistent")));
+    }
+
+    [Fact]
+    public void ProvideAssemblyPath_PathMultipleTimes()
+    {
+        this.loader.ProvideAssemblyPath("no good path");
+        this.loader.ProvideAssemblyPath(Path.Combine(Environment.CurrentDirectory, "nonexistent.dll"));
+        this.loader.ProvideAssemblyPath(Path.Combine(Environment.CurrentDirectory, "nonexistent.dll"));
+    }
+
 #if NETFRAMEWORK
     private class AppDomainHelper : MarshalByRefObject
     {


### PR DESCRIPTION
This pull request primarily focuses on enhancing the `NetFrameworkAssemblyResolver` class in the `src/Nerdbank.NetStandardBridge` project. The changes introduce a fallback mechanism for assembly resolution, add a new method for providing assembly paths, and improve the assembly loading process. Additionally, the `IsExternalInit` package has been added to the project.

Here are the most significant changes:

Addition of new package:

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R9): Added the `IsExternalInit` package version `1.0.3` to the project.

Enhancements to `NetFrameworkAssemblyResolver`:

* [`src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs`](diffhunk://#diff-a344ffe4bea645ecc772be26dec40f68f7c3e833303dc93c11aa6f0fe5a45b81R296-R367): Introduced the `ProvideAssemblyPath` method that allows suggesting a path for an assembly that might be loaded later.

* [`src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs`](diffhunk://#diff-a344ffe4bea645ecc772be26dec40f68f7c3e833303dc93c11aa6f0fe5a45b81L273-R410): Modified the `Load` method and added the `LoadFrom` method to improve the assembly loading process. The `Load` method now uses the fallback mechanism if the assembly cannot be found, while the `LoadFrom` method first tries to load the assembly using standard load rules and then falls back to the specified path if the assembly cannot be found.
The LoadFrom behavior emulates .NET Framework where an assembly loaded via LoadFrom will be able to resolve its own assembly references from the same directory that it itself is loaded from.

* [`src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs`](diffhunk://#diff-a344ffe4bea645ecc772be26dec40f68f7c3e833303dc93c11aa6f0fe5a45b81R570-R694): Added the `SearchInFallbackTable` method to support the new fallback mechanism for assembly resolution. This method searches for the assembly in the fallback lookup paths if no codebase was provided.

* [`src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs`](diffhunk://#diff-a344ffe4bea645ecc772be26dec40f68f7c3e833303dc93c11aa6f0fe5a45b81L392-R547): Updated the `FileExists` method to use a cache for path existence checks, improving performance by avoiding redundant file system queries.

* [`src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs`](diffhunk://#diff-a344ffe4bea645ecc772be26dec40f68f7c3e833303dc93c11aa6f0fe5a45b81L616-R873): Enhanced the `VSAssemblyLoadContext` class to support the new fallback mechanism for assembly resolution. This includes adding the `DependencySearchPath` property and updating the constructor. [[1]](diffhunk://#diff-a344ffe4bea645ecc772be26dec40f68f7c3e833303dc93c11aa6f0fe5a45b81L616-R873) [[2]](diffhunk://#diff-a344ffe4bea645ecc772be26dec40f68f7c3e833303dc93c11aa6f0fe5a45b81L626-R883)