### PR TITLE
Expose APIs to allow consumers to review .config file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ***A reference + facade library to bring additional types to .NET Standard.***
 
-[![NuGet package](https://img.shields.io/nuget/v/Nerdbank.NetStandardBridge.svg)](https://nuget.org/packages/Nerdbank.NetStandardBridge)
+[![NuGet package](https://img.shields.io/nuget/v/Nerdbank.NetStandardBridge.svg)](https://www.nuget.org/packages/Nerdbank.NetStandardBridge)
 [![Build Status](https://dev.azure.com/andrewarnott/OSS/_apis/build/status/Nerdbank.NetStandardBridge/Nerdbank.NetStandardBridge?branchName=main)](https://dev.azure.com/andrewarnott/OSS/_build/latest?definitionId=36&branchName=main)
 
 ## Features

--- a/src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs
+++ b/src/Nerdbank.NetStandardBridge/NetFrameworkAssemblyResolver.cs
@@ -113,7 +113,7 @@ public class NetFrameworkAssemblyResolver
             }
 
             string? publicKeyToken = assemblyIdentity.Attribute("publicKeyToken")?.Value;
-            if (publicKeyToken is null)
+            if (publicKeyToken is null or "null")
             {
                 continue;
             }

--- a/src/Nerdbank.NetStandardBridge/net462/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/net462/PublicAPI.Unshipped.txt
@@ -1,7 +1,26 @@
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.AssemblyLoadRules() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.BindingRedirects.get -> System.Collections.Immutable.ImmutableList<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.CodeBasePaths.get -> System.Collections.Immutable.ImmutableDictionary<System.Version!, string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.TryGetMatch(System.Version! desiredAssemblyVersion, out System.Version! matchingAssemblyVersion, out string? assemblyFile) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.AssemblySimpleName() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Name.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.PublicKeyToken.get -> System.ReadOnlyMemory<byte>
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BaseDir.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect(string! oldVersion, string! newVersion) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Contains(System.Version! version) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.NewVersion.get -> System.Version!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.OldVersion.get -> (System.Version! Start, System.Version! End)
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.AssemblyName?
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName, bool validateResult) -> System.Reflection.AssemblyName?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.HookupResolver() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.KnownAssemblies.get -> System.Collections.ObjectModel.ReadOnlyDictionary<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName, Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules>!
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
@@ -9,6 +28,8 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(stri
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(object? obj) -> bool
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.GetHashCode() -> int
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute (forwarded, contained in mscorlib)
 System.Runtime.InteropServices.TypeLibVersionAttribute (forwarded, contained in mscorlib)
 System.Runtime.InteropServices.TypeLibVersionAttribute.MajorVersion.get -> int (forwarded, contained in mscorlib)

--- a/src/Nerdbank.NetStandardBridge/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/net8.0/PublicAPI.Unshipped.txt
@@ -1,8 +1,27 @@
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.AssemblyLoadRules() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.BindingRedirects.get -> System.Collections.Immutable.ImmutableList<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.CodeBasePaths.get -> System.Collections.Immutable.ImmutableDictionary<System.Version!, string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.TryGetMatch(System.Version! desiredAssemblyVersion, out System.Version! matchingAssemblyVersion, out string? assemblyFile) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.AssemblySimpleName() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Name.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.PublicKeyToken.get -> System.ReadOnlyMemory<byte>
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BaseDir.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect(string! oldVersion, string! newVersion) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Contains(System.Version! version) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.NewVersion.get -> System.Version!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.OldVersion.get -> (System.Version! Start, System.Version! End)
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.AssemblyName?
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName, bool validateResult) -> System.Reflection.AssemblyName?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.HookupResolver(System.Runtime.Loader.AssemblyLoadContext! loadContext) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.HookupResolver(System.Runtime.Loader.AssemblyLoadContext! loadContext, bool blockMoreResolvers) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.KnownAssemblies.get -> System.Collections.ObjectModel.ReadOnlyDictionary<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName, Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules>!
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.LoadFrom(string! assemblyPath) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
@@ -12,6 +31,8 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.RegisterBootstrappingAss
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(object? obj) -> bool
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.GetHashCode() -> int
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute (forwarded, contained in System.Runtime.InteropServices)
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute.ImportedFromTypeLibAttribute(string! tlbFile) -> void (forwarded, contained in System.Runtime.InteropServices)
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute.Value.get -> string! (forwarded, contained in System.Runtime.InteropServices)

--- a/src/Nerdbank.NetStandardBridge/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,25 @@
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.AssemblyLoadRules() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.BindingRedirects.get -> System.Collections.Immutable.ImmutableList<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.CodeBasePaths.get -> System.Collections.Immutable.ImmutableDictionary<System.Version!, string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.TryGetMatch(System.Version! desiredAssemblyVersion, out System.Version! matchingAssemblyVersion, out string? assemblyFile) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.AssemblySimpleName() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Name.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.PublicKeyToken.get -> System.ReadOnlyMemory<byte>
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BaseDir.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect(string! oldVersion, string! newVersion) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Contains(System.Version! version) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.NewVersion.get -> System.Version!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.OldVersion.get -> (System.Version! Start, System.Version! End)
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.AssemblyName?
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName, bool validateResult) -> System.Reflection.AssemblyName?
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.KnownAssemblies.get -> System.Collections.ObjectModel.ReadOnlyDictionary<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName, Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules>!
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
@@ -8,6 +27,8 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(stri
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(object? obj) -> bool
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.GetHashCode() -> int
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute.ImportedFromTypeLibAttribute(string! tlbFile) -> void
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute.Value.get -> string!

--- a/src/Nerdbank.NetStandardBridge/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.NetStandardBridge/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,6 +1,25 @@
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.AssemblyLoadRules() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.BindingRedirects.get -> System.Collections.Immutable.ImmutableList<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.CodeBasePaths.get -> System.Collections.Immutable.ImmutableDictionary<System.Version!, string!>!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules.TryGetMatch(System.Version! desiredAssemblyVersion, out System.Version! matchingAssemblyVersion, out string? assemblyFile) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.AssemblySimpleName() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Name.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.PublicKeyToken.get -> System.ReadOnlyMemory<byte>
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BaseDir.get -> string!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect() -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.BindingRedirect(string! oldVersion, string! newVersion) -> void
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Contains(System.Version! version) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.Equals(Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect other) -> bool
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.NewVersion.get -> System.Version!
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.BindingRedirect.OldVersion.get -> (System.Version! Start, System.Version! End)
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.AssemblyName?
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.GetAssemblyNameByPolicy(System.Reflection.AssemblyName! assemblyName, bool validateResult) -> System.Reflection.AssemblyName?
+Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.KnownAssemblies.get -> System.Collections.ObjectModel.ReadOnlyDictionary<Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName, Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblyLoadRules>!
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.Load(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly?
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.NetFrameworkAssemblyResolver(string! configFile, string? baseDir = null, System.Diagnostics.TraceSource? traceSource = null) -> void
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProbingPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
@@ -8,6 +27,8 @@ Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.ProvideAssemblyPath(stri
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents.InvalidConfiguration = 0 -> Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceEvents
 Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.TraceSource.get -> System.Diagnostics.TraceSource?
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.Equals(object? obj) -> bool
+override Nerdbank.NetStandardBridge.NetFrameworkAssemblyResolver.AssemblySimpleName.GetHashCode() -> int
 System.Runtime.InteropServices.ImportedFromTypeLibAttribute (forwarded, contained in netstandard)
 System.Runtime.InteropServices.TypeLibVersionAttribute (forwarded, contained in netstandard)
 System.Runtime.InteropServices.TypeLibVersionAttribute.MajorVersion.get -> int (forwarded, contained in netstandard)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1-alpha",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
This pull request includes several changes to the `NetFrameworkAssemblyResolver` class in the `Nerdbank.NetStandardBridge` project. The changes primarily aim to enhance validation, improve code readability, and expand the public API.